### PR TITLE
Add OpenCL framework on OSX.

### DIFF
--- a/src/cl-oclapi.lisp
+++ b/src/cl-oclapi.lisp
@@ -22,6 +22,7 @@
 (eval-when (:load-toplevel)
   (define-foreign-library libopencl
     (:windows (:default "OpenCL"))
+    (:darwin (:framework "OpenCL"))
     (t        (:default "libOpenCL")))
 
   (unless (foreign-library-loaded-p 'libopencl)


### PR DESCRIPTION
This links the OpenCL framework on OSX. With this change I can load the library, but some tests fail.